### PR TITLE
Fix missing FormulaContext provider

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,30 +1,32 @@
 import { Tabs } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { FormulaProvider } from '../contexts/FormulaProvider';
 
 export default function TabLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <Tabs
-        screenOptions={{
-          headerShown: false,
-          tabBarStyle: {
-            backgroundColor: '#111111',
-            borderTopWidth: 0,
-          },
-          tabBarActiveTintColor: '#DBFF00',
-          tabBarInactiveTintColor: '#666',
-        }}
-      >
-        <Tabs.Screen
-          name="index"
-          options={{
-            title: 'Calculator',
-            tabBarIcon: ({ color, size }) => (
-              <Ionicons name="calculator" size={size} color={color} />
-            ),
+      <FormulaProvider>
+        <Tabs
+          screenOptions={{
+            headerShown: false,
+            tabBarStyle: {
+              backgroundColor: '#111111',
+              borderTopWidth: 0,
+            },
+            tabBarActiveTintColor: '#DBFF00',
+            tabBarInactiveTintColor: '#666',
           }}
-        />
+        >
+          <Tabs.Screen
+            name="index"
+            options={{
+              title: 'Calculator',
+              tabBarIcon: ({ color, size }) => (
+                <Ionicons name="calculator" size={size} color={color} />
+              ),
+            }}
+          />
         <Tabs.Screen
           name="history"
           options={{
@@ -43,7 +45,8 @@ export default function TabLayout() {
             ),
           }}
         />
-      </Tabs>
+        </Tabs>
+      </FormulaProvider>
     </GestureHandlerRootView>
   );
 }

--- a/contexts/FormulaProvider.tsx
+++ b/contexts/FormulaProvider.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { FormulaContext } from './FormulaContext';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const DEFAULT_FORMULAS = ['lander', 'oconner', 'lombardi', 'mayhem', 'wathen', 'brzycki', 'epley'];
+
+export function FormulaProvider({ children }: Props) {
+  const [selectedFormulas, setSelectedFormulasState] = useState<string[]>(DEFAULT_FORMULAS);
+  const [weightUnit, setWeightUnit] = useState<'kg' | 'lbs'>('kg');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('selectedFormulas');
+        if (stored) {
+          setSelectedFormulasState(JSON.parse(stored));
+        }
+      } catch {}
+    })();
+  }, []);
+
+  const setSelectedFormulas = async (formulas: string[]) => {
+    try {
+      setSelectedFormulasState(formulas);
+      await AsyncStorage.setItem('selectedFormulas', JSON.stringify(formulas));
+    } catch {}
+  };
+
+  return (
+    <FormulaContext.Provider value={{ selectedFormulas, setSelectedFormulas, weightUnit, setWeightUnit }}>
+      {children}
+    </FormulaContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a `FormulaProvider` so selected formulas persist and have defaults
- wrap tabs in the new provider

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a74f2d4832eb299795f5d3dbc24