### PR TITLE
Fix entrypoint with expo-router

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,1 @@
-import { registerRootComponent } from 'expo';
-
-import App from './App';
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);
+import 'expo-router/entry';


### PR DESCRIPTION
## Summary
- update `index.js` to use expo-router entry

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7d72d92c832eaeb4455cce09ca99